### PR TITLE
Added support for working directory for launched executables

### DIFF
--- a/Wox.Plugin.Runner/Command.cs
+++ b/Wox.Plugin.Runner/Command.cs
@@ -10,6 +10,7 @@ namespace Wox.Plugin.Runner
         public string Shortcut { get; set; }
         public string Description { get; set; }
         public string Path { get; set; }
+        public string WorkingDirectory { get; set; }
         public string ArgumentsFormat { get; set; }
     }
 }

--- a/Wox.Plugin.Runner/ConfigurationLoader.cs
+++ b/Wox.Plugin.Runner/ConfigurationLoader.cs
@@ -51,13 +51,15 @@ namespace Wox.Plugin.Runner
                 {
                     Description = "Sample Command 1",
                     Shortcut = "shortcut1",
-                    Path = @"C:\mycommand1.exe"
+                    Path = @"C:\mycommand1.exe",
+                    WorkingDirectory = @"C:\workpath1"
                 },
                 new Command
                 {
                     Description = "Sample Command 2",
                     Shortcut = "shortcut2",
-                    Path = @"C:\mycommand2.exe"
+                    Path = @"C:\mycommand2.exe",
+                    WorkingDirectory = @"C:\workpath2"
                 }
             };
         }

--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Controls;
@@ -49,7 +50,12 @@ namespace Wox.Plugin.Runner
             try
             {
                 var args = GetProcessArguments( command, query );
-                Process.Start( args.FileName, args.Arguments );
+                var startInfo = new ProcessStartInfo(args.FileName, args.Arguments);
+                if (args.WorkingDirectory != null) {
+                    startInfo.WorkingDirectory = args.WorkingDirectory;
+                }
+                Process.Start(startInfo);
+                // Process.Start( args.FileName, args.Arguments );
             }
             catch ( Win32Exception w32Ex )
             {
@@ -68,7 +74,7 @@ namespace Wox.Plugin.Runner
 
         private static ProcessArguments GetProcessArguments( Command c, Query q )
         {
-            string argString = String.Empty;
+            var argString = String.Empty;
             if ( !String.IsNullOrEmpty( c.ArgumentsFormat ) )
             {
                 var arguments = q.Terms.ToList();
@@ -78,10 +84,16 @@ namespace Wox.Plugin.Runner
                 else
                     argString = String.Empty;
             }
+            var workingDir = c.WorkingDirectory;
+            if (string.IsNullOrEmpty(workingDir)) {
+                // Use directory where executable is based.
+                workingDir = Path.GetDirectoryName(c.Path);
+            }
             return new ProcessArguments
             {
                 FileName = c.Path,
-                Arguments = argString
+                Arguments = argString,
+                WorkingDirectory = workingDir
             };
         }
 
@@ -89,6 +101,7 @@ namespace Wox.Plugin.Runner
         {
             public string FileName { get; set; }
             public string Arguments { get; set; }
+            public string WorkingDirectory { get; set; }
         }
     }
 }

--- a/Wox.Plugin.Runner/Settings/CommandViewModel.cs
+++ b/Wox.Plugin.Runner/Settings/CommandViewModel.cs
@@ -14,6 +14,7 @@ namespace Wox.Plugin.Runner.Settings
             description = command.Description;
             shortcut = command.Shortcut;
             path = command.Path;
+            workingDirectory = command.WorkingDirectory;
             argumentsFormat = command.ArgumentsFormat;
         }
 
@@ -61,6 +62,20 @@ namespace Wox.Plugin.Runner.Settings
             }
         }
 
+        private string workingDirectory;
+
+        public string WorkingDirectory
+        {
+            get {
+                return workingDirectory;
+                
+            }
+            set {
+                Set(() => WorkingDirectory, ref workingDirectory, value);
+                CheckDirty();
+            }
+        }
+
         private string argumentsFormat;
         public string ArgumentsFormat
         {
@@ -97,6 +112,7 @@ namespace Wox.Plugin.Runner.Settings
                     Description = Description,
                     Shortcut = Shortcut,
                     Path = Path,
+                    WorkingDirectory = WorkingDirectory,
                     ArgumentsFormat = ArgumentsFormat
                 };
         }
@@ -107,6 +123,7 @@ namespace Wox.Plugin.Runner.Settings
                 ( Description != Command.Description ) ||
                 ( Shortcut != Command.Shortcut ) ||
                 ( Path != Command.Path ) ||
+                ( WorkingDirectory != Command.WorkingDirectory ) ||
                 ( ArgumentsFormat != Command.ArgumentsFormat );
         }
     }

--- a/Wox.Plugin.Runner/Settings/RunnerSettings.xaml
+++ b/Wox.Plugin.Runner/Settings/RunnerSettings.xaml
@@ -5,7 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:s="clr-namespace:Wox.Plugin.Runner.Settings"
              xmlns:infra="clr-namespace:Wox.Plugin.Runner.Infrastructure"
-             mc:Ignorable="d" Width="575" Height="326">
+             mc:Ignorable="d" Width="575" Height="326"
+             d:DataContext="{d:DesignInstance s:RunnerSettingsViewModel}">
     <UserControl.Resources>
         <infra:NullToVisibilityConverter x:Key="nullToVisibilityConverter" />
         <Style x:Key="hcs" TargetType="{x:Type GridViewColumnHeader}">
@@ -52,9 +53,12 @@
                 <TextBox Height="23" Margin="88,45,10,0" Text="{Binding SelectedCommand.Shortcut, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top"/>
                 <Label Content="Path:" HorizontalAlignment="Left" Margin="10,72,0,0" VerticalAlignment="Top"/>
                 <TextBox Name="tbPath" Height="23" Margin="88,76,10,0" Text="{Binding SelectedCommand.Path, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top"/>
-                <Button Content="Browse" Name="btnBrowse" Margin="192,104,10,0" VerticalAlignment="Top" Click="btnBrowse_Click" />
-                <Label Content="Arguments:" HorizontalAlignment="Left" Margin="10,125,0,0" VerticalAlignment="Top"/>
-                <TextBox Height="23" Margin="88,129,10,0" Text="{Binding SelectedCommand.ArgumentsFormat, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top"/>
+                <Button Content="Browse" Name="btnBrowsePath" Margin="192,104,10,0" VerticalAlignment="Top" Click="btnBrowsePath_Click" />
+                <Label Content="Working dir:" HorizontalAlignment="Left" Margin="10,125,0,0" VerticalAlignment="Top"/>
+                <TextBox Name="tbWorkDir" Height="23" Margin="88,129,10,0" Text="{Binding SelectedCommand.WorkingDirectory, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top"/>
+                <Button Content="Browse" Name="btnBrowseWorkDir" Margin="192,160,10,0" VerticalAlignment="Top" Click="btnBrowseWorkDir_Click" />
+                <Label Content="Arguments:" HorizontalAlignment="Left" Margin="10,187,0,0" VerticalAlignment="Top"/>
+                <TextBox Height="23" Margin="88,190,10,0" Text="{Binding SelectedCommand.ArgumentsFormat, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top"/>
             </Grid>
             <Grid Grid.Row="1" Margin="0,10,0,0">
                 <Grid.ColumnDefinitions>

--- a/Wox.Plugin.Runner/Settings/RunnerSettings.xaml.cs
+++ b/Wox.Plugin.Runner/Settings/RunnerSettings.xaml.cs
@@ -1,18 +1,21 @@
 ﻿using GalaSoft.MvvmLight;
-using Microsoft.Win32;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
+using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+
+using OpenFileDialog = Microsoft.Win32.OpenFileDialog;
+using UserControl = System.Windows.Controls.UserControl;
 
 namespace Wox.Plugin.Runner.Settings
 {
@@ -32,7 +35,7 @@ namespace Wox.Plugin.Runner.Settings
             DataContext = viewModel;
         }
 
-        private void btnBrowse_Click( object sender, RoutedEventArgs e )
+        private void btnBrowsePath_Click( object sender, RoutedEventArgs e )
         {
             var dialog = new OpenFileDialog();
             dialog.DereferenceLinks = false;
@@ -40,6 +43,15 @@ namespace Wox.Plugin.Runner.Settings
             if ( result == true )
             {
                 tbPath.Text = dialog.FileName;
+            }
+        }
+
+        private void btnBrowseWorkDir_Click( object sender, RoutedEventArgs e ) {
+            using (var dialog = new FolderBrowserDialog()) {
+                dialog.Description = "Select working directory";
+                if (dialog.ShowDialog() == DialogResult.OK) {
+                    tbWorkDir.Text = dialog.SelectedPath;
+                }
             }
         }
     }

--- a/Wox.Plugin.Runner/Wox.Plugin.Runner.csproj
+++ b/Wox.Plugin.Runner/Wox.Plugin.Runner.csproj
@@ -59,6 +59,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
I had some issues where an application would not start due to the fact that the working directory seemed to be set to its default value. This change adds a working directory input field to the settings and changes the startup behavior in two ways:
1. If the working directory has been set, this will be used.
2. If it has not been set or is empty, the directory of the executable will be used as the starting directory.

Note that I also introduced a dependency on `System.Windows.Forms` with the introduction of a `FolderBrowserDialog` instance. If this is unwanted, the directory picker functionality will probably have to be replaced or removed.
